### PR TITLE
Add end state checking to CompositeDialogueFlow

### DIFF
--- a/docs/MultipleComponentsTutorial.md
+++ b/docs/MultipleComponentsTutorial.md
@@ -6,6 +6,8 @@ This shows an example of using multiple components in a single dialogue system.
 Here are two separate dialogue agents:
 
 ```python
+from emora_stdm import DialogueFlow, CompositeDialogueFlow
+
 A = DialogueFlow('start')
 A.load_transitions({
     'state': 'start',
@@ -13,7 +15,7 @@ A.load_transitions({
         'error': {
             '`What\'s your favorite book?`': {
                 'error': {
-                    '`Cool!`': 'end',
+                    '`Cool!`': '__end__',
                     '`Okay.`': 'movies:movie_question'
                 }
             }

--- a/emora_stdm/state_transition_dialogue_manager/composite_dialogue_flow.py
+++ b/emora_stdm/state_transition_dialogue_manager/composite_dialogue_flow.py
@@ -40,7 +40,8 @@ class CompositeDialogueFlow:
         test in interactive mode
         :return: None
         """
-        while True:
+        # Run the CompositeDialogueFlow until we reach an end state
+        while self.controller().state() != self.controller().end_state():
             if self.controller().speaker() == DialogueFlow.Speaker.SYSTEM:
                 t1 = time()
                 response = self.system_turn(debugging=debugging)


### PR DESCRIPTION
Addresses the issue presented in #20.
* Bring CDF.run behaviour closer to that of DF.run by having it evaluate whether the current state is the end state
* Update the docs to use the correct end state